### PR TITLE
add missing prereqs

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,11 +9,15 @@ WriteMakefile(
         NAME              => 'DBD::Crate',
         VERSION_FROM      => 'lib/DBD/Crate.pm',
         ABSTRACT_FROM     => 'lib/DBD/Crate.pm',
+        CONFIGURE_REQUIRES => {
+            'DBI'               => 1.50,
+        },
         PREREQ_PM         => {
             'DBI'               => 1.50,
             'HTTP::Tiny'        => 0.055,
             'JSON::MaybeXS'     => 1.003003,
             'Test::More'        => 0,
+            'Digest::SHA1'      => 0,
         },
         LICENSE        => 'perl',
         AUTHOR         => 'Mamod Mehyar <mamod.mehyar@gmail.com>',


### PR DESCRIPTION
With this patch it installs correctly on vanilla perl (e.g. installed via perlbrew).

Since `DBI` is used in Makefile.PL it has to be added to the `CONFIGURE_REQUIRES` section too. `Digest::SHA1` was missing in `PREREQS_PM` for some reason.
